### PR TITLE
Add full composer/packagist support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "php-ffmpeg/php-ffmpeg",
+    "name": "soluciones-gbh/php-ffmpeg",
     "type": "library",
     "description": "FFMpeg PHP, an Object Oriented library to communicate with AVconv / ffmpeg",
     "keywords": ["video processing", "video", "audio processing", "audio", "avconv", "ffmpeg", "avprobe", "ffprobe"],


### PR DESCRIPTION
Now you're not allowed to use packagist.org because the forked repository uses the same vendor/package name as an original one: `php-ffmpeg/php-ffmpeg`.

Let's fix this to be allowed to use composer.
