### PR TITLE
Add a missing contract declaration for `use Illuminate\Contracts\Foundation\Application`

### DIFF
--- a/src/FFMpeg/FFMpegServiceProvider.php
+++ b/src/FFMpeg/FFMpegServiceProvider.php
@@ -12,6 +12,7 @@
 namespace FFMpeg;
 
 use Doctrine\Common\Cache\ArrayCache;
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 
 class FFMpegServiceProvider extends ServiceProvider


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | yes

In Laravel 5.3 there is an exception:
```
[Symfony\Component\Debug\Exception\FatalThrowableError]                                                                                                                                                  
  Type error: Argument 1 passed to FFMpeg\FFMpegServiceProvider::FFMpeg\{closure}() must be an instance of FFMpeg\Application, instance of Illuminate\Foundation\Application given, called in /Users/user/projects/project/vendor/laravel/framework/src/Illuminate/Container/Container.php on line 290
```